### PR TITLE
allow newer version of joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "petreboy14@gmail.com"
   },
   "dependencies": {
-    "joi": "1.2.0"
+    "joi": ">=1.2.0"
   },
   "devDependencies": {
     "express": "3.1.0",


### PR DESCRIPTION
why lock us to 1.2.0?

another solution:
instead of declaring joi as a dependency declare it as a peer dependency,
so users will have to seperatly install joi first:

"peerDependencies": {
    "joi": "*"
  }
