### PR TITLE
pass options to joi

### DIFF
--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -50,7 +50,7 @@ exports.joiValidate = function joiValidate(validations, options) {
       bodyExtras = copyObject(body, items, validations,options.strict, true);
     }
 
-    var err = Joi.validate(items, validations);
+    var err = Joi.validate(items, validations, options);
     if (err) {
       next(err);
     } else {


### PR DESCRIPTION
thus being able to override some of joi default validate options.
notice though: the plugin and joi share the options object so they shouldn't use the same option names.
