### PR TITLE
work with prototype-less objects

### DIFF
--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -9,6 +9,10 @@
 var Joi = require('joi');
 var util = require('util');
 
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
 /**
  * A per route validation option
  *
@@ -83,7 +87,7 @@ function copyObject(from, to, validations, strict, decode) {
   var extras = {};
   if (from) {
     for (var key in from) {
-      if (from.hasOwnProperty(key) && (!validations || strict || validations.hasOwnProperty(key))) {
+      if (hasOwnProperty(from, key) && (!validations || strict || hasOwnProperty(validations, key))) {
         try {
           to[key] = (decode && typeof(from[key]) === 'string') ? decodeURIComponent(from[key]) : from[key];
         } catch (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -139,6 +139,39 @@ describe('express-joi tests', function () {
       });
     });
 
+    it('should pass successfully with prototype-less objects', function (done) {
+      var schema = { name: expressJoi.Joi.string() };
+
+      function fakeBody(req, res, next) {
+        req.body = Object.create(null);
+        req.body.name = 'Linus';
+        next();
+      }
+
+      app.get('/prototypeless', fakeBody, expressJoi.joiValidate(schema), function returnFunc(req, res) {
+        res.send(200, { hello: 'world' });
+      });
+
+      request.get('http://localhost:8181/prototypeless', function (err, res, body) {
+        if (err) {
+          done(err);
+        }
+
+        res.statusCode.should.equal(200);
+        should.exist(body);
+
+        try {
+          body = JSON.parse(body);
+        } catch (err) {
+          done(err);
+        }
+
+        body.should.have.property('hello');
+        body.hello.should.equal('world');
+        done();
+      });
+    });
+
     after(function () {
       server.close();
     });


### PR DESCRIPTION
I first reported this at  but it turns out that the bug was in this library.

> Since the data validated by this library often is user provided input, I think we should consider it "unsafe". Instead of using `hasOwnProperty` directly on input objects, I think it would be better to make sure that we are actually using the builtin method `hasOwnProperty` instead of the one on the provided object.
> 
> This simple input from the user currently causes an error: `{ hasOwnProperty: 'hello' }`.
> 
> This could be fixed by changing the use of hasOwnProperty to use an already defined function. E.g.
> 
> ``` javascript
> function hasOwnProperty (obj, prop) {
>   return Object.prototype.hasOwnProperty.call(obj, prop)
> }
> 
> // Instead of this:
> input.hasOwnProperty(schema.key)
> 
> // We us this:
> hasOwnProperty(input, schema.key)
> ```
> 
> This would also have the benefit of being able to validate objects without a prototype (e.g. created by `Object.create(null)`). This objects are usually used when you want to use a hash map, which I also think that the input to this library usually is.
> 
> You can read more on why you shouldn't use a normal js object as a hash map here: [Blog post by Guillermo Rauch](http://www.devthought.com/2012/01/18/an-object-is-not-a-hash/), [Article on 2ality](http://www.2ality.com/2012/01/objects-as-maps.html)
> 
> In `multer`, an express middleware for accepting multipart forms, we provide the data with an prototype-less object. This lead one of our users to report expressjs/multer#171 to us, which would be solved by this.

This patch fixes that and adds a test for it.
