### PR TITLE
Update to latest Joi, allow validation errors to be handled by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ var updateUserSchema = {
 app.get('/users', expressJoi.joiValidate(getUsersSchema), handleUsers);
 app.put('/users/:userId', expressJoi.joiValidate(updateUserSchema), handleUpdateUser);
 
+// Add an error middleware that will handle validation errors
+function joiErrorHandler(err, req, res, next) {
+  if (e instanceof ValidationError) {
+    res.status(400);
+    // use err.details for better dispatch, see https://github.com/hapijs/joi/blob/master/API.md#errors
+    res.end(JSON.stringify({ message: formatMessage(err.message) }));
+  } else {
+    next(err);
+  }
+}
+app.use(joiErrorHandler);
+
 app.listen(8080);
 ```
 If a validation error occurs it will either be handled by your express error handling middleware or thrown.

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ app.put('/users/:userId', expressJoi.joiValidate(updateUserSchema), handleUpdate
 
 // Add an error middleware that will handle validation errors
 function joiErrorHandler(err, req, res, next) {
-  if (e && e.error && e.error.name === 'ValidationError') {
+  if (e && e.name === 'ValidationError') {
     res.status(400);
     // use err.details for better dispatch, see https://github.com/hapijs/joi/blob/master/API.md#errors
-    res.end(JSON.stringify({ message: formatMessage(err.message) }));
+    res.end(JSON.stringify({ message: formatMessage(e.message) }));
   } else {
-    next(err);
+    next(e);
   }
 }
 app.use(joiErrorHandler);

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 express-joi
 ===========
 
-[![Build Status](https://travis-ci.org/petreboy14/express-joi.png)](https://travis-ci.org/petreboy14/express-joi)
+[![Circle CI](https://circleci.com/gh/parkan/express-joi.svg?style=svg)](https://circleci.com/gh/parkan/express-joi)
 
 
 A validation middleware for express using the [Joi validation](https://github.com/spumko/joi) suite from Eran Hammer/Walmart Labs.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ app.put('/users/:userId', expressJoi.joiValidate(updateUserSchema), handleUpdate
 
 // Add an error middleware that will handle validation errors
 function joiErrorHandler(err, req, res, next) {
-  if (e instanceof ValidationError) {
+  if (e && e.error && e.error.name === 'ValidationError') {
     res.status(400);
     // use err.details for better dispatch, see https://github.com/hapijs/joi/blob/master/API.md#errors
     res.end(JSON.stringify({ message: formatMessage(err.message) }));

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 4.1.1

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -52,8 +52,7 @@ exports.joiValidate = function joiValidate(validations, options) {
 
     var err = Joi.validate(items, validations, options);
     if (err) {
-      res.status(400);
-      res.end(JSON.stringify({ message: err.message }));
+      next(err);
     } else {
       copyObject(paramExtras, items, null, null);
       copyObject(queryExtras, items, null, null);

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -54,7 +54,7 @@ exports.joiValidate = function joiValidate(validations, options) {
 
     var err = Joi.validate(items, validations, options);
     if (err && err.error) {
-      next(err);
+      next(err.error);
     } else {
       copyObject(paramExtras, items, null, null);
       copyObject(queryExtras, items, null, null);

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -19,7 +19,7 @@ var util = require('util');
  * @public
  */
 exports.joiValidate = function joiValidate(validations, options) {
-  options = options || {};
+  options = options || {"abortEarly": false};
   var strict = !!options.strict;
   delete options.strict;
 

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -19,7 +19,9 @@ var util = require('util');
  * @public
  */
 exports.joiValidate = function joiValidate(validations, options) {
-  options = options || { strict: true };
+  options = options || {};
+  var strict = !!options.strict;
+  delete options.strict;
 
   /**
   * The middleware that handles the route validation
@@ -41,17 +43,17 @@ exports.joiValidate = function joiValidate(validations, options) {
     var items = {};
 
     // Copy all of the items from the express data into our single items object
-    var paramExtras = copyObject(params, items, validations, options.strict, true);
-    var queryExtras = copyObject(query, items, validations, options.strict, true);
+    var paramExtras = copyObject(params, items, validations, strict, true);
+    var queryExtras = copyObject(query, items, validations, strict, true);
     var bodyExtras = {};
 
     // Only store body methods on calls that may have a body
     if (method !== "GET" && method !== "DELETE") {
-      bodyExtras = copyObject(body, items, validations, options.strict, true);
+      bodyExtras = copyObject(body, items, validations, strict, true);
     }
 
     var err = Joi.validate(items, validations, options);
-    if (err) {
+    if (err && err.error) {
       next(err);
     } else {
       copyObject(paramExtras, items, null, null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-joi",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "An A validation middleware for express using the Joi validation suite from Eran Hammer/Walmart Labs",
   "contributors": {
     "name": "Peter Henning",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=0.6"
+    "node": ">=4.0"
   },
   "scripts": {
     "test": "mocha -R spec",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "petreboy14@gmail.com"
   },
   "dependencies": {
-    "joi": "2.9.0"
+    "joi": "7.*.*"
   },
   "devDependencies": {
     "express": "3.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -26,14 +26,15 @@ describe('express-joi tests', function () {
       var schemaError = null;
       var schema = null;
       try {
-        schema = {
-          username: expressJoi.Joi.string().alphanum().min(3).max(30).with('birthyear').required(),
-          password: expressJoi.Joi.string().regex(/[a-zA-Z0-9]{3,30}/).without('access_token'),
+        schema = Joi.object().keys({
+          username: expressJoi.Joi.string().alphanum().min(3).max(30),
+          password: expressJoi.Joi.string().regex(/[a-zA-Z0-9]{3,30}/),
           access_token: expressJoi.Joi.string(),
           birthyear: expressJoi.Joi.number().min(1850).max(2012),
           email: expressJoi.Joi.string().email()
-        };
+        }).with('username', 'birthyear').without('password', 'access_token');
       } catch (err) {
+        console.log(err);
         schemaError = err;
       }
       should.exist(schema);
@@ -51,7 +52,12 @@ describe('express-joi tests', function () {
       app.use(express.bodyParser());
       app.use(app.router);
       app.use(function (err, req, res, next) {
-        res.send(400, {message: err.message});
+        console.log(err);
+        if(err && err.error && err.error.name === 'ValidationError'){
+          res.send(400, {message: err.error.message});
+        } else {
+          next(err);
+        }
       });
 
       server = app.listen(8181, function () {
@@ -97,6 +103,7 @@ describe('express-joi tests', function () {
         done();
       });
     });
+
     it('should fail if an item does not have correct validation', function (done) {
       request.get('http://localhost:8181/users?limit=-1&offset=5&name=tom', function (err, res, body) {
         if (err) {
@@ -112,7 +119,7 @@ describe('express-joi tests', function () {
         }
 
         body.should.have.property('message');
-        body.message.should.equal('the value of limit must be larger than or equal to 1');
+        body.message.should.equal('child "limit" fails because ["limit" must be larger than or equal to 1]');
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,7 @@ describe('express-joi tests', function () {
       app.use(express.bodyParser());
       app.use(app.router);
       app.use(function (err, req, res, next) {
-        res.send(500, {message: err.message});
+        res.send(400, {message: err.message});
       });
 
       server = app.listen(8181, function () {

--- a/test/test.js
+++ b/test/test.js
@@ -53,8 +53,8 @@ describe('express-joi tests', function () {
       app.use(app.router);
       app.use(function (err, req, res, next) {
         console.log(err);
-        if(err && err.error && err.error.name === 'ValidationError'){
-          res.send(400, {message: err.error.message});
+        if(err && err.name === 'ValidationError'){
+          res.send(400, {message: err.message});
         } else {
           next(err);
         }


### PR DESCRIPTION
This introduces two major changes:

1) upgrade Joi to 7.x, which among other things throws `Error` with `name: ValidationError`, and update the callsites and tests accordingly
2) undo f940de6c4997ebacb95aebbbb80188fa72b69066, which made it impossible to handle validation errors in any custom way, and adds appropriate documentation and example in tests 
