### PR TITLE
Updates to use Joi 7.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
+  - "4.2.1"
+  - "5.0.0"

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -19,7 +19,7 @@ var util = require('util');
  * @public
  */
 exports.joiValidate = function joiValidate(validations, options) {
-
+  options = options || {"allowUnknown": false};
   /**
   * The middleware that handles the route validation
   *
@@ -40,13 +40,13 @@ exports.joiValidate = function joiValidate(validations, options) {
     var items = {};
 
     // Copy all of the items from the express data into our single items object
-    var paramExtras = copyObject(params, items, validations, options.strict, true);
-    var queryExtras = copyObject(query, items, validations, options.strict, true);
+    var paramExtras = copyObject(params, items, validations, !options.allowUnknown, true);
+    var queryExtras = copyObject(query, items, validations, !options.allowUnknown, true);
     var bodyExtras = {};
 
     // Only store body methods on calls that may have a body
     if (method !== "GET" && method !== "DELETE") {
-      bodyExtras = copyObject(body, items, validations, options.strict, true);
+      bodyExtras = copyObject(body, items, validations, !options.allowUnknown, true);
     }
 
     var err = Joi.validate(items, validations, options);

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -49,10 +49,10 @@ exports.joiValidate = function joiValidate(validations, options) {
       bodyExtras = copyObject(body, items, validations, !options.allowUnknown, true);
     }
 
-    var err = Joi.validate(items, validations, options);
-    if (err) {
+    var result = Joi.validate(items, validations, options);
+    if (result.error) {
       res.status(400);
-      res.end(JSON.stringify({ message: err.message }));
+      res.end(JSON.stringify({ "error": result.error }));
     } else {
       copyObject(paramExtras, items, null, null);
       copyObject(queryExtras, items, null, null);

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -19,7 +19,6 @@ var util = require('util');
  * @public
  */
 exports.joiValidate = function joiValidate(validations, options) {
-  options = options || { strict: true };
 
   /**
   * The middleware that handles the route validation

--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -52,7 +52,11 @@ exports.joiValidate = function joiValidate(validations, options) {
     var result = Joi.validate(items, validations, options);
     if (result.error) {
       res.status(400);
-      res.end(JSON.stringify({ "error": result.error }));
+      var errorList = [];
+      result.error.details.map(function(item){
+        errorList.push(item.message);
+      });
+      res.end(JSON.stringify({ "error": { "validation": errorList } }));
     } else {
       copyObject(paramExtras, items, null, null);
       copyObject(queryExtras, items, null, null);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "petreboy14@gmail.com"
   },
   "dependencies": {
-    "joi": "2.9.0"
+    "joi": "^7.1.0"
   },
   "devDependencies": {
     "express": "3.1.0",


### PR DESCRIPTION
I hope you like these changes, so that we can use the latest Joi code.  The way Joi outputs the error messages has changed as well.  I have tried to make the 400 error JSON response a simple as possible.  The new Joi version outputs a lot of info that you wouldn't want to repeat back out.
